### PR TITLE
Fix a few typos and errors in the problem statements and type signatures

### DIFF
--- a/src/main/scala/challenge/Parser.scala
+++ b/src/main/scala/challenge/Parser.scala
@@ -264,10 +264,10 @@ object Parser {
    * producing all their results but fails on the first failing
    * parser of the list.
    *
-   * scala> Parser.sequence(List(Parser.char, Parser.char, Parser.char)).run("hello")
-   *  = Ok(ParseState(lo,hel))
+   * scala> Parser.sequence(List(Parser.character, Parser.character, Parser.character)).run("hello")
+   *  = Ok(ParseState(lo,List(h, e, l)))
    *
-   * scala> Parser.sequence(List(Parser.char, Parser.fail(NotEnoughInput), Parser.char)).run("hello")
+   * scala> Parser.sequence(List(Parser.character, (Parser.failed(NotEnoughInput): Parser[Char]), Parser.character)).run("hello")
    *  = Fail(NotEnoughInput)
    */
   def sequence[A](parsers: List[Parser[A]]): Parser[List[A]] =
@@ -279,10 +279,10 @@ object Parser {
    * attempt to produce the given number of values.
    *
    *
-   * scala> Parser.thisMany(5, Parser.char)).run("hello")
-   *  = Ok(ParseState(,hello))
+   * scala> Parser.thisMany(5, Parser.character).run("hello")
+   *  = Ok(ParseState(,List(h, e, l, l, o)))
    *
-   * scala> Parser.thisMany(6, Parser.char)).run("hello")
+   * scala> Parser.thisMany(6, Parser.character).run("hello")
    *  = Fail(NotEnoughInput)
    */
   def thisMany[A](n: Int, parse: Parser[A]): Parser[List[A]] =
@@ -339,7 +339,7 @@ object PersonParser {
    *
    *  <name> <age> <phone> <address>
    */
-  def personParser: Parser[String] =
+  def personParser: Parser[Person] =
     ???
 
   /**
@@ -355,9 +355,9 @@ object PersonParser {
     ???
 
   def Data = List(
-    "fred 32 123.456-1213# 301 cobblestone"
-  , "barney 31 123.456.1214# 303 cobblestone"
-  , "homer 39 555.123.939# 742 evergreen"
-  , "flanders 39 555.123.939# 744 evergreen"
+    "Fred 32 123.456-1213# 301 cobblestone"
+  , "Barney 31 123.456.1214# 303 cobblestone"
+  , "Homer 39 555.123.939# 742 evergreen"
+  , "Flanders 39 555.123.939# 744 evergreen"
   )
 }

--- a/src/main/scala/intro/Monoid.scala
+++ b/src/main/scala/intro/Monoid.scala
@@ -25,8 +25,8 @@ case class Min(n: Int)
 case class Max(n: Int)
 case class Size(n: Int)
 case class Endo[A](f: A => A)
-case class First[A](first: A)
-case class Last[A](last: A)
+case class First[A](first: Option[A])
+case class Last[A](last: Option[A])
 
 object Monoid {
   /**

--- a/src/main/scala/intro/Result.scala
+++ b/src/main/scala/intro/Result.scala
@@ -118,7 +118,7 @@ sealed trait Result[A] {
    *  = Ok(10)
    *
    * scala> Fail[Int](NotEnoughInput) ||| Fail[Int](UnexpectedInput("?"))
-   *  = Fail(NotEnoughInput)
+   *  = Fail[Int](UnexpectedInput("?"))
    */
   def |||(alternative: => Result[A]): Result[A] =
     ???
@@ -153,7 +153,7 @@ object Result {
    * scala> Lists.sequence(List[Result[Int]](Ok(1), Fail(NotEnoughInput), Ok(3)))
    * resX: Result[List[Int]] = Fail(NotEnoughInput)
    */
-  def sequence[A](xs: List[Option[A]]): Option[List[A]] =
+  def sequence[A](xs: List[Result[A]]): Result[List[A]] =
     ???
 }
 


### PR DESCRIPTION
Hopefully most changes make sense by themselves. One I feel deserves a little more explanation is in the type hint for the `sequence` function in `Parser.scala`:

As it is it will fail like so

``` bash
   scala> Parser.sequence(List(Parser.character, Parser.failed(NotEnoughInput), Parser.character)).run("hello")

 <console>:14: error: no type parameters for method sequence: (parsers: List[challenge.Parser[A]])challenge.Parser[List[A]] exist so that it can be applied to arguments (List[challenge.Parser[_ <: Char]])
  --- because ---
 argument expression's type is not compatible with formal parameter type;
  found   : List[challenge.Parser[_ <: Char]]
  required: List[challenge.Parser[?A]]
               Parser.sequence(List(Parser.character, Parser.failed(NotEnoughInput), Parser.character)).run("hello")
                      ^
```

But we can type hint the failed parser, after which it works fine:

``` bash
   scala> Parser.sequence(List(Parser.character, (Parser.failed(NotEnoughInput): Parser[Char]), Parser.character)).run("hello")
= Fail(NotEnoughInput)
```
