### PR TITLE
Upgrade scala version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.10.3
+  - 2.11.5
 
 jdk:
   - openjdk6

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,25 @@
 name := "introduction-to-fp-in-scala"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.5"
 
 libraryDependencies ++= Seq(
-  "org.scalaz"     %% "scalaz-core"                  % "7.0.5"
-, "org.scalaz"     %% "scalaz-scalacheck-binding"    % "7.0.5"    % "test"
-, "org.specs2"     %% "specs2"                       % "2.2.2"    % "test"
-, "org.scalacheck" %% "scalacheck"                   % "1.10.0"   % "test"
+  "org.scalaz"        %% "scalaz-core"                  % "7.1.1"
+, "org.scalaz"        %% "scalaz-scalacheck-binding"    % "7.1.1"    % "test"
+, "org.scalaz.stream" %% "scalaz-stream"                % "0.6a"
+, "org.specs2"        %% "specs2"                       % "2.4.5"    % "test"
+, "org.scalacheck"    %% "scalacheck"                   % "1.12.2"   % "test"
 )
 
 resolvers ++= Seq(
-  "oss snapshots" at "http://oss.sonatype.org/content/repositories/snapshots"
-, "oss releases"  at "http://oss.sonatype.org/content/repositories/releases"
+  "oss snapshots"       at "http://oss.sonatype.org/content/repositories/snapshots"
+, "oss releases"        at "http://oss.sonatype.org/content/repositories/releases"
+, "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 )
 
 scalacOptions := Seq(
   "-deprecation"
 , "-unchecked"
-, "-Ywarn-all"
+, "-Xfatal-warnings"
 , "-Xlint"
 , "-feature"
 , "-language:_"


### PR DESCRIPTION
Also updates scalaz, scalacheck, specs2.

I found I needed to explicitly add scalar-stream to the dependencies plus add another resolver so that it actually found it. I grabbed this info from the scala-stream [github](http://github.com/scalaz/scalaz-stream) 

Also the `-Ywarn-all` seems to have been removed, so I used the closest thing I could see in the scalar options `-Xfatal-warnings`