### PR TITLE
Fix foldLeft type signature in documentation

### DIFF
--- a/src/main/scala/intro/List.scala
+++ b/src/main/scala/intro/List.scala
@@ -33,7 +33,7 @@ object Lists {
    *
    * {{{
    *   List[A]#foldRight[B](z: B)(f: (A, B) => B)
-   *   List[A]#foldLeft[B](z: B)(f: (B, A) => A)
+   *   List[A]#foldLeft[B](z: B)(f: (B, A) => B)
    * }}}
    *
    */


### PR DESCRIPTION
I'm learning programming through these exercises and found a type signature that might be incorrect in the docs. Please let me know if I'm wrong :)